### PR TITLE
Remove support for align-wide styles

### DIFF
--- a/inc/class-deli.php
+++ b/inc/class-deli.php
@@ -19,6 +19,7 @@ class Deli {
 	 * @since 1.0
 	 */
 	public function __construct() {
+		add_action( 'after_setup_theme', array( $this, 'setup' ), 20 );
 		add_filter( 'storefront_woocommerce_args', array( $this, 'woocommerce_support' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_styles' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_child_styles' ), 99 );
@@ -31,6 +32,20 @@ class Deli {
 			add_filter( 'storefront_loop_columns', array( $this, 'loop_columns' ) );
 			add_filter( 'storefront_products_per_page', array( $this, 'products_per_page' ) );
 		}
+	}
+
+	/**
+	 * Sets up theme defaults and registers support for various WordPress features.
+	 *
+	 * Note that this function is hooked into the after_setup_theme hook, which
+	 * runs before the init hook. The init hook is too late for some features, such
+	 * as indicating support for post thumbnails.
+	 */
+	public function setup() {
+		/**
+		 * Remove support for full and wide align images.
+		 */
+		remove_theme_support( 'align-wide' );
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -12,16 +12,28 @@
     "npm": ">=1.1.0"
   },
   "devDependencies": {
-    "grunt": "~0.4.5",
-    "grunt-contrib-jshint": "^0.11.2",
-    "grunt-contrib-uglify": "~0.9.1",
-    "grunt-contrib-watch": "~0.6.1",
-    "grunt-wp-i18n": "^0.5.2",
-    "grunt-rtlcss": "~1.6.0",
-    "grunt-sass": "^1.0.0",
-    "node-sass": "^3.2.0",
-    "susy": "^2.2.5",
-    "node-bourbon": "~4.2.3",
-    "colors": "^1.1.2"
+    "autoprefixer": "^6.7.7",
+    "grunt": "~1.0.1",
+    "grunt-checktextdomain": "^1.0.1",
+    "grunt-contrib-compress": "^1.4.3",
+    "grunt-contrib-copy": "^1.0.0",
+    "grunt-contrib-cssmin": "~2.1.0",
+    "grunt-contrib-jshint": "~1.1.0",
+    "grunt-contrib-uglify": "~2.3.0",
+    "grunt-contrib-watch": "^1.0.0",
+    "grunt-postcss": "^0.8.0",
+    "grunt-rtlcss": "~2.0.1",
+    "grunt-sass": "~2.0.0",
+    "grunt-stylelint": "~0.9.0",
+    "grunt-wp-i18n": "^1.0.0",
+    "node-bourbon": "~4.2.8",
+    "node-sass": "~4.5.2",
+    "stylelint": "~8.2.0",
+    "susy": "~2.2.12"
+  },
+  "scripts": {
+    "build": "grunt",
+    "css": "grunt css",
+    "watch": "grunt watch"
   }
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -288,7 +288,7 @@ table tbody tr:nth-child(2n) td,
     right: 0;
     width: 100%;
     height: 9px;
-    background: -webkit-linear-gradient(transparent 0%, transparent 0%), -webkit-linear-gradient(135deg, #f9f9f9 33.33%, transparent 33.33%) 0 0%, transparent -webkit-linear-gradient(45deg, #f9f9f9 33.33%, transparent 33.33%) 100% 0%;
+    background: -webkit-linear-gradient(transparent 0%, transparent 0%), -webkit-linear-gradient(-135deg, #f9f9f9 33.33%, transparent 33.33%) 100% 0%, transparent -webkit-linear-gradient(-45deg, #f9f9f9 33.33%, transparent 33.33%) 100% 0%;
     background-size: 0px 100%, 9px 9px, 9px 9px;
     -webkit-transform: rotate(-180deg);
     -moz-transform: rotate(-180deg);
@@ -393,7 +393,7 @@ table.cart td.actions {
     right: 0;
     width: 100%;
     height: 7px;
-    background: -webkit-linear-gradient(transparent 0%, transparent 0%), -webkit-linear-gradient(135deg, rgba(255, 255, 255, 0.85) 33.33%, transparent 33.33%) 0 0%, transparent -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.85) 33.33%, transparent 33.33%) 100% 0%;
+    background: -webkit-linear-gradient(transparent 0%, transparent 0%), -webkit-linear-gradient(-135deg, rgba(255, 255, 255, 0.85) 33.33%, transparent 33.33%) 100% 0%, transparent -webkit-linear-gradient(-45deg, rgba(255, 255, 255, 0.85) 33.33%, transparent 33.33%) 100% 0%;
     background-size: 0px 100%, 9px 9px, 9px 9px;
     -webkit-transform: rotate(-180deg);
     -moz-transform: rotate(-180deg);


### PR DESCRIPTION
Remove support for align-wide styles in the Gutenberg editor.

With support for align-wide:

<img width="673" alt="screenshot 2018-11-28 at 15 59 23" src="https://user-images.githubusercontent.com/1177726/49164257-ace81d80-f326-11e8-8c53-31e8ec729092.png">

Without support for align-wide:

<img width="673" alt="screenshot 2018-11-28 at 15 58 52" src="https://user-images.githubusercontent.com/1177726/49164270-b1acd180-f326-11e8-8c6d-40c9e0557bdd.png">

Closes #37.