### PR TITLE
Don't replace whole array of defaults

### DIFF
--- a/inc/class-deli-customizer.php
+++ b/inc/class-deli-customizer.php
@@ -42,24 +42,24 @@ class Deli_Customizer {
 	 * Returns an array of the desired default Storefront options
 	 * @return array
 	 */
-	public function get_deli_defaults() {
-		return apply_filters( 'deli_default_settings', $args = array(
-			'storefront_heading_color'               => '#2b2b2b',
-			'storefront_footer_heading_color'        => '#ffffff',
-			'storefront_header_background_color'     => '#b64902',
-			'storefront_footer_background_color'     => '#2b2b2b',
-			'storefront_header_link_color'           => '#ffffff',
-			'storefront_header_text_color'           => '#ffffff',
-			'storefront_button_background_color'     => '#0e7784',
-			'storefront_button_text_color'           => '#ffffff',
-			'storefront_button_alt_background_color' => '#b64902',
-			'storefront_button_alt_text_color'       => '#ffffff',
-			'storefront_footer_link_color'           => '#e4decd',
-			'storefront_text_color'                  => '#615d59',
-			'storefront_footer_text_color'           => '#ffffff',
-			'storefront_accent_color'                => '#0e7784',
-			'background_color'                       => '645846',
-		) );
+	public function get_deli_defaults( $defaults = array() ) {
+		$defaults['storefront_heading_color']               = '#2b2b2b';
+		$defaults['storefront_footer_heading_color']        = '#ffffff';
+		$defaults['storefront_header_background_color']     = '#b64902';
+		$defaults['storefront_footer_background_color']     = '#2b2b2b';
+		$defaults['storefront_header_link_color']           = '#ffffff';
+		$defaults['storefront_header_text_color']           = '#ffffff';
+		$defaults['storefront_button_background_color']     = '#0e7784';
+		$defaults['storefront_button_text_color']           = '#ffffff';
+		$defaults['storefront_button_alt_background_color'] = '#b64902';
+		$defaults['storefront_button_alt_text_color']       = '#ffffff';
+		$defaults['storefront_footer_link_color']           = '#e4decd';
+		$defaults['storefront_text_color']                  = '#615d59';
+		$defaults['storefront_footer_text_color']           = '#ffffff';
+		$defaults['storefront_accent_color']                = '#0e7784';
+		$defaults['background_color']                       = '645846';
+
+		return apply_filters( 'deli_default_settings', $defaults );
 	}
 
 	/**


### PR DESCRIPTION
We're currently replacing the whole array of defaults which causes issues with new values added to Storefront over the years not being available because they are being replaced.

In this PR we edit specific array keys and return the rest of the array unchanged.

This PR should only require a code review.